### PR TITLE
Optimize Docker image and update docker-compose documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,26 @@
 FROM ubuntu:xenial
 
 # Install apt packages
-RUN apt-get update
-RUN apt-get install -y python-pip
+RUN apt update && \
+    apt upgrade -y && \
+    apt install -y python-pip
 RUN pip install --upgrade pip
+
 # Clean downloaded apt packages after install
-RUN apt-get clean
+RUN apt clean && \
+    apt autoremove
 RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install python packages
-RUN pip install   'sphinx              == 1.6.2'
-RUN pip install   'sphinx-autobuild    == 0.6.0'
-RUN pip install   'sphinx_rtd_theme    == 0.2.4'
-RUN pip install   'sphinx-tabs         == 1.1.10'
+RUN pip install 'sphinx              == 1.6.2' && \
+    pip install 'sphinx-autobuild    == 0.6.0' && \
+    pip install 'sphinx_rtd_theme    == 0.2.4' && \
+    pip install 'sphinx-tabs         == 1.1.10'
 
 # Set the locale
-ENV   LANG C.UTF-8
-ENV   LANGUAGE C.UTF-8
-ENV   LC_ALL C.UTF-8
+ENV LANG C.UTF-8
+ENV LANGUAGE C.UTF-8
+ENV LC_ALL C.UTF-8
 
 # Expose sphinx-autobuild documentation served port
 EXPOSE 8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,6 @@
-FROM ubuntu:xenial
+FROM python:3-alpine
 
-# Install apt packages
-RUN apt update && \
-    apt upgrade -y && \
-    apt install -y python-pip
 RUN pip install --upgrade pip
-
-# Clean downloaded apt packages after install
-RUN apt clean && \
-    apt autoremove
-RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install python packages
 RUN pip install 'sphinx              == 1.6.2' && \

--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ A fully formatted version of this documentation can be found on [Read the Docs](
 
 ## For contributors
 
-The sources for the documentation can be found in the [docs/](docs/) folder. The [Dockerfile](Dockerfile) and the [docker-compose.yml file](docker-compose.yml) in the root directory can be used with [docker](https://www.docker.com/) to automatically generate a fully formatted version of the source files for double-checking before submitting a pull request.
+The sources for the documentation can be found in the [docs/](docs/) folder. The [Dockerfile](Dockerfile) and the [docker-compose.yml file](docker-compose.yml) in the root directory can be used with [Docker Compose](https://docs.docker.com/compose/) to automatically generate a fully formatted version of the source files while editing. After starting the Docker container with `docker-compose up -d`, the formatted documentation can be accessed with a Web browser at http://localhost:8000/ on the Docker host. It is updated, i.e., regenerated from the source files, on the fly. Please double-check any changes in the fully formatted version before submitting a pull request.


### PR DESCRIPTION
This pull request
* reduces the download/build time of the Sphinx Docker image and its storage footprint by more than 50% (see commit message of 47a69ee for details);
* fixes a potential caching bug when running installation commands separately (see below); and
* adds documentation on how to use docker compose to prepare pull requests for the documentation.

If the first change (change of the OS basis for the Sphinx image) is undesired, I can undo the corresponding commit. The second change (caching bug fix), however, should remain, as it also affects the original `apt` commands (having docker cache the result of `apt update` will result in errors in the subsequent `apt install` steps after a few months as the repository data will be outdated).